### PR TITLE
Add a PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/sub_pr.md
+++ b/.github/PULL_REQUEST_TEMPLATE/sub_pr.md
@@ -1,0 +1,6 @@
+<!--- Replace the ?? with the appropriate pull request number in ateles-source.
+      Make it a draft PR, and add it to review, once the ateles-source PR has
+      been merged, such that this branch refers to a commit on the main branch
+      of ateles-source before merging!
+ -->
+See [PR in mus-source](https://github.com/apes-suite/ateles-source/pull/??).


### PR DESCRIPTION
The sub_pr template supports the creation of pull requests that track pull requests in the submodule atl.